### PR TITLE
Handle missing survey in question retrieval

### DIFF
--- a/src/main/java/com/example/myapp/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/com/example/myapp/service/impl/SurveyServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.myapp.repository.InMemoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,11 +38,13 @@ public class SurveyServiceImpl implements SurveyService{
     public List<Question> getAllQuestionsOfSurvey(String surveyId) {
 
         List<Survey> surveys = getAllSurveys();
-        Optional<Survey> optionalSurvey =  surveys.stream().filter(
-                survey -> survey.getId().equals(surveyId)
-        ).findFirst();
+        Optional<Survey> optionalSurvey =  surveys.stream()
+                .filter(survey -> survey.getId().equals(surveyId))
+                .findFirst();
 
-        return optionalSurvey.get().getQuestions();
+        return optionalSurvey
+                .map(Survey::getQuestions)
+                .orElse(new ArrayList<>());
 
     }
 

--- a/src/test/java/com/example/myapp/service/impl/SurveyServiceImplTest.java
+++ b/src/test/java/com/example/myapp/service/impl/SurveyServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.example.myapp.service.impl;
+
+import com.example.myapp.model.Question;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class SurveyServiceImplTest {
+
+    @Autowired
+    private SurveyService surveyService;
+
+    @Test
+    void getAllQuestionsOfSurveyReturnsEmptyListForUnknownSurvey() {
+        List<Question> questions = surveyService.getAllQuestionsOfSurvey("Unknown");
+        assertNotNull(questions);
+        assertTrue(questions.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Avoid NoSuchElementException when retrieving questions for a non-existent survey
- Add test covering unknown survey question lookup

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897ff8406d8832daafc7f9e385858d0