### PR TITLE
Return deletion status for survey questions

### DIFF
--- a/src/main/java/com/example/myapp/controller/SurveyController.java
+++ b/src/main/java/com/example/myapp/controller/SurveyController.java
@@ -82,7 +82,10 @@ public class SurveyController {
             @PathVariable String surveyId,
             @PathVariable String questionId
     ){
-        surveyService.deleteQuestionOfSurvey(surveyId, questionId);
+        boolean removed = surveyService.deleteQuestionOfSurvey(surveyId, questionId);
+        if(!removed){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/myapp/service/impl/SurveyService.java
+++ b/src/main/java/com/example/myapp/service/impl/SurveyService.java
@@ -16,7 +16,7 @@ public interface SurveyService {
 
     String addNewSurveyQuestion(String surveyId, Question question);
 
-    void deleteQuestionOfSurvey(String surveyId, String questionId);
+    boolean deleteQuestionOfSurvey(String surveyId, String questionId);
 
 }
 

--- a/src/main/java/com/example/myapp/service/impl/SurveyServiceImpl.java
+++ b/src/main/java/com/example/myapp/service/impl/SurveyServiceImpl.java
@@ -72,11 +72,11 @@ public class SurveyServiceImpl implements SurveyService{
     }
 
     @Override
-    public void deleteQuestionOfSurvey(String surveyId, String questionId) {
+    public boolean deleteQuestionOfSurvey(String surveyId, String questionId) {
 
         List<Question> questions = getAllQuestionsOfSurvey(surveyId);
 
-        questions.removeIf(
+        return questions.removeIf(
                 question -> question.getId().equals(questionId)
         );
     }


### PR DESCRIPTION
## Summary
- Update `SurveyService` and its implementation to report whether a question was deleted
- Handle missing questions in `SurveyController.deleteQuestionOfSurvey` by returning 404

## Testing
- ⚠️ `mvn -q test` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689bb18d2ef0832daaf8d6293c0e9ad8